### PR TITLE
🪄 feat: provide `NotebookPanel.IContentFactory`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "npm run build:css && jlpm build:lib && jlpm build:labextension:dev",
-    "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
+    "build:prod": "jlpm clean && npm run build:css && jlpm build:lib && jlpm build:labextension",
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
   },
   "jupyterlab": {
     "extension": true,
-    "outputDir": "jupyterlab_mystjs/labextension"
+    "outputDir": "jupyterlab_mystjs/labextension",
+    "disabledExtensions": ["@jupyterlab/notebook-extension:factory"]
   },
   "jupyter-releaser": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "myst-frontmatter": "^0.0.5",
     "myst-to-react": "^0.1.20",
     "myst-transforms": "^0.0.13",
-    "mystjs": "^0.0.15"
+    "mystjs": "^0.0.15",
+    "katex": "^0.15.2"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const plugin: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
   autoStart: true,
   activate: (app: JupyterFrontEnd, editorServices: IEditorServices) => {
     const editorFactory = editorServices.factoryService.newInlineEditor;
-    console.log("Activated MyST content factory");
+    console.log('Activated MyST content factory');
     return new MySTContentFactory({ editorFactory });
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,108 +3,23 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
-import { ICommandPalette, ISessionContextDialogs } from '@jupyterlab/apputils';
-
 import { IEditorServices } from '@jupyterlab/codeeditor';
 
-import {
-  INotebookTracker,
-  INotebookWidgetFactory,
-  NotebookWidgetFactory
-} from '@jupyterlab/notebook';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-
-import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import { NotebookPanel } from '@jupyterlab/notebook';
 import { MySTContentFactory } from './MySTContentFactory';
-import { LabIcon } from '@jupyterlab/ui-components';
-
-import mystIconSvg from '../style/mystlogo.svg';
-
-const mystIcon = new LabIcon({
-  name: 'myst-notebook-extension:mystIcon',
-  svgstr: mystIconSvg
-});
-
-function loadKatex() {
-  if (typeof document === 'undefined') {
-    return;
-  }
-  const head = document.getElementsByTagName('HEAD')[0];
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.type = 'text/css';
-  link.href = 'https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css';
-  head.appendChild(link);
-}
 
 /**
- * Initialization data for the jupyterlab-mystjs extension.
+ * The notebook cell factory provider.
  */
-const plugin: JupyterFrontEndPlugin<void> = {
-  id: 'jupyterlab-mystjs:plugin',
+const plugin: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
+  id: '@jupyterlab-mystjs:plugin',
+  provides: NotebookPanel.IContentFactory,
+  requires: [IEditorServices],
   autoStart: true,
-  optional: [ITranslator, ICommandPalette],
-  requires: [
-    IEditorServices,
-    IRenderMimeRegistry,
-    ISessionContextDialogs,
-    INotebookWidgetFactory,
-    INotebookTracker
-  ],
-  activate: (
-    app: JupyterFrontEnd,
-    editorServices: IEditorServices,
-    rendermime: IRenderMimeRegistry,
-    sessionContextDialogs: ISessionContextDialogs,
-    notebookFactory: NotebookWidgetFactory.IFactory,
-    notebookTracker: INotebookTracker,
-    translator: ITranslator | null,
-    palette: ICommandPalette | null
-  ) => {
-    console.log('JupyterLab extension jupyterlab-mystjs is activated!');
-    loadKatex();
-
-    const contentFactory = new MySTContentFactory();
-
-    const factory = new NotebookWidgetFactory({
-      name: 'Jupyter MyST Notebook',
-      // label: trans.__("Jupyter MyST Notebook"), // will be needed in JupyterLab 4
-      fileTypes: ['notebook'],
-      defaultFor: ['notebook'],
-      modelName: notebookFactory.modelName ?? 'notebook',
-      preferKernel: notebookFactory.preferKernel ?? true,
-      canStartKernel: notebookFactory.canStartKernel ?? true,
-      rendermime,
-      contentFactory,
-      editorConfig: notebookFactory.editorConfig,
-      notebookConfig: notebookFactory.notebookConfig,
-      mimeTypeService: editorServices.mimeTypeService,
-      sessionDialogs: sessionContextDialogs,
-      toolbarFactory: notebookFactory.toolbarFactory,
-      translator: nullTranslator
-    });
-
-    let id = 0;
-
-    factory.widgetCreated.connect((sender, widget) => {
-      // If the notebook panel does not have an ID, assign it one.
-      widget.id = widget.id || `myst-notebook-${++id}`;
-
-      // Set up the title icon
-      widget.title.icon = mystIcon ?? '';
-      widget.toolbar.title.icon = mystIcon;
-      widget.title.iconClass = '';
-      widget.title.iconLabel = 'MyST Notebook';
-
-      // Notify the widget tracker if restore data needs to update.
-      widget.context.pathChanged.connect(() => {
-        void (notebookTracker as any).save(widget);
-      });
-      // Add the notebook panel to the tracker.
-      void (notebookTracker as any).add(widget);
-    });
-
-    app.docRegistry.addWidgetFactory(factory);
+  activate: (app: JupyterFrontEnd, editorServices: IEditorServices) => {
+    const editorFactory = editorServices.factoryService.newInlineEditor;
+    console.log("Activated MyST content factory");
+    return new MySTContentFactory({ editorFactory });
   }
 };
 

--- a/style/base.css
+++ b/style/base.css
@@ -4,6 +4,7 @@
     https://jupyterlab.readthedocs.io/en/stable/developer/css.html
 */
 @import url('app.css');
+@import url('~katex/dist/katex.css');
 
 /* Allow overflow on input areas for myst */
 .jp-MySTMarkdownCell .jp-InputArea,


### PR DESCRIPTION
Alternative to #16, closes #3 and fixes #10

This PR replaced JupyterLab's `NotebookPanel.IContentFactory` with our own `MySTContentFactory`. The consequence of this is  that any other extensions asking for `IContentFactory` or other notebook-related tokens will be given a MyST renderer. 

I think this is a good thing; we want to be the renderer for *all* notebooks, if we are installed. This PR fixes #10, and cleans up how we bundle KaTeX.

I'm not a JS expert, so take this as my idea of best practice, and do with it what you will!

NB, there is the Python `jupyterlab-katex` package that also enables KaTeX math rendering in JupyterLab. However, it is intended to be used with the `ILatexTypesetter` extension, which I assume we ignore in this project (the typesetter renders fragments of math to `HTMLElement`, and we sideline that entire pipeline). So, I opted to directly depend upon KaTeX and import the style.

We might want to declare KaTeX a shared module (https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#deduplication-of-dependencies), but I'm not yet clear on how strict a version we require, etc. I think we would want
```json
{
	"bundled": true,
    "singleton": true,
    "strictVersion": true
}
```
to say:
- bundle this dependency
- try to use the same dependency everyone is using
- make sure it satisfies our version bounds