### PR TITLE
feat: support "legacy mode" opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pip install jupyterlab_mystjs
 ## Usage
 
 By default, the MyST renderer becomes the default notebook renderer. This means that MyST notebook rendering works out-of-the-box with Jupytext and other notebook-aware extensions. Whilst this extension is in a pre-release state, there is also a "legacy mode" that integrates MyST rendering as an additional `Open With` option that does not replace the default notebook renderer. To enable legacy mode, disable the `jupyterlab-mystjs:plugin` plugin with
+
 ```bash
 jupyter labextension disable jupyterlab-mystjs:plugin
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ To install the extension, execute:
 pip install jupyterlab_mystjs
 ```
 
+## Usage
+
+By default, the MyST renderer becomes the default notebook renderer. This means that MyST notebook rendering works out-of-the-box with Jupytext and other notebook-aware extensions. Whilst this extension is in a pre-release state, there is also a "legacy mode" that integrates MyST rendering as an additional `Open With` option that does not replace the default notebook renderer. To enable legacy mode, disable the `jupyterlab-mystjs:plugin` plugin with
+```bash
+jupyter labextension disable jupyterlab-mystjs:plugin
+```
+
 ## Uninstall
 
 To remove the extension, execute:

--- a/package.json
+++ b/package.json
@@ -109,9 +109,6 @@
   },
   "jupyterlab": {
     "extension": true,
-    "outputDir": "jupyterlab_mystjs/labextension",
-    "disabledExtensions": [
-      "@jupyterlab/notebook-extension:factory"
-    ]
+    "outputDir": "jupyterlab_mystjs/labextension"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,23 @@
-import {JupyterFrontEnd, JupyterFrontEndPlugin} from '@jupyterlab/application';
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
 
-import {IEditorServices} from '@jupyterlab/codeeditor';
+import { IEditorServices } from '@jupyterlab/codeeditor';
 
-import {INotebookTracker, INotebookWidgetFactory, NotebookPanel, NotebookWidgetFactory} from '@jupyterlab/notebook';
-import {MySTContentFactory} from './MySTContentFactory';
+import {
+  INotebookTracker,
+  INotebookWidgetFactory,
+  NotebookPanel,
+  NotebookWidgetFactory
+} from '@jupyterlab/notebook';
+import { MySTContentFactory } from './MySTContentFactory';
 
-import {ISessionContextDialogs} from '@jupyterlab/apputils';
-import {IRenderMimeRegistry} from '@jupyterlab/rendermime';
+import { ISessionContextDialogs } from '@jupyterlab/apputils';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
-import {ITranslator} from '@jupyterlab/translation';
-import {LabIcon} from '@jupyterlab/ui-components';
+import { ITranslator } from '@jupyterlab/translation';
+import { LabIcon } from '@jupyterlab/ui-components';
 
 import mystIconSvg from '../style/mystlogo.svg';
 
@@ -61,7 +69,9 @@ const legacyPlugin: JupyterFrontEndPlugin<void> = {
     if (existingContentFactory instanceof MySTContentFactory) {
       return;
     }
-    console.log('JupyterLab extension jupyterlab-mystjs (legacy mode) is activated!');
+    console.log(
+      'JupyterLab extension jupyterlab-mystjs (legacy mode) is activated!'
+    );
 
     const contentFactory = new MySTContentFactory();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,110 @@
-import {
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin
-} from '@jupyterlab/application';
+import {JupyterFrontEnd, JupyterFrontEndPlugin} from '@jupyterlab/application';
 
-import { IEditorServices } from '@jupyterlab/codeeditor';
+import {IEditorServices} from '@jupyterlab/codeeditor';
 
-import { NotebookPanel } from '@jupyterlab/notebook';
-import { MySTContentFactory } from './MySTContentFactory';
+import {INotebookTracker, INotebookWidgetFactory, NotebookPanel, NotebookWidgetFactory} from '@jupyterlab/notebook';
+import {MySTContentFactory} from './MySTContentFactory';
+
+import {ISessionContextDialogs} from '@jupyterlab/apputils';
+import {IRenderMimeRegistry} from '@jupyterlab/rendermime';
+
+import {ITranslator} from '@jupyterlab/translation';
+import {LabIcon} from '@jupyterlab/ui-components';
+
+import mystIconSvg from '../style/mystlogo.svg';
+
+const mystIcon = new LabIcon({
+  name: 'myst-notebook-extension:mystIcon',
+  svgstr: mystIconSvg
+});
 
 /**
- * The notebook cell factory provider.
+ * The notebook content factory provider.
  */
 const plugin: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
-  id: '@jupyterlab-mystjs:plugin',
+  id: 'jupyterlab-mystjs:plugin',
   provides: NotebookPanel.IContentFactory,
   requires: [IEditorServices],
   autoStart: true,
   activate: (app: JupyterFrontEnd, editorServices: IEditorServices) => {
+    console.log('JupyterLab extension jupyterlab-mystjs is activated!');
     const editorFactory = editorServices.factoryService.newInlineEditor;
-    console.log('Activated MyST content factory');
     return new MySTContentFactory({ editorFactory });
   }
 };
 
-export default plugin;
+/**
+ * The legacy-mode content factory.
+ */
+const legacyPlugin: JupyterFrontEndPlugin<void> = {
+  id: 'jupyterlab-mystjs:legacyPlugin',
+  optional: [ITranslator],
+  requires: [
+    IEditorServices,
+    IRenderMimeRegistry,
+    ISessionContextDialogs,
+    INotebookWidgetFactory,
+    INotebookTracker,
+    NotebookPanel.IContentFactory
+  ],
+  autoStart: true,
+  activate: (
+    app: JupyterFrontEnd,
+    editorServices: IEditorServices,
+    rendermime: IRenderMimeRegistry,
+    sessionContextDialogs: ISessionContextDialogs,
+    notebookFactory: NotebookWidgetFactory.IFactory,
+    notebookTracker: INotebookTracker,
+    existingContentFactory: NotebookPanel.IContentFactory,
+    translator: ITranslator | null
+  ) => {
+    if (existingContentFactory instanceof MySTContentFactory) {
+      return;
+    }
+    console.log('JupyterLab extension jupyterlab-mystjs (legacy mode) is activated!');
+
+    const contentFactory = new MySTContentFactory();
+
+    const factory = new NotebookWidgetFactory({
+      name: 'Jupyter MyST Notebook',
+      // label: trans.__("Jupyter MyST Notebook"), // will be needed in JupyterLab 4
+      fileTypes: ['notebook', 'markdown', 'myst'],
+      defaultFor: ['notebook'],
+      modelName: notebookFactory.modelName ?? 'notebook',
+      preferKernel: notebookFactory.preferKernel ?? true,
+      canStartKernel: notebookFactory.canStartKernel ?? true,
+      rendermime,
+      contentFactory,
+      editorConfig: notebookFactory.editorConfig,
+      notebookConfig: notebookFactory.notebookConfig,
+      mimeTypeService: editorServices.mimeTypeService,
+      sessionDialogs: sessionContextDialogs,
+      toolbarFactory: notebookFactory.toolbarFactory,
+      translator: translator ?? undefined
+    });
+
+    let id = 0;
+
+    factory.widgetCreated.connect((sender, widget) => {
+      // If the notebook panel does not have an ID, assign it one.
+      widget.id = widget.id || `myst-notebook-${++id}`;
+
+      // Set up the title icon
+      widget.title.icon = mystIcon ?? '';
+      widget.toolbar.title.icon = mystIcon;
+      widget.title.iconClass = '';
+      widget.title.iconLabel = 'MyST Notebook';
+
+      // Notify the widget tracker if restore data needs to update.
+      widget.context.pathChanged.connect(() => {
+        void (notebookTracker as any).save(widget);
+      });
+      // Add the notebook panel to the tracker.
+      void (notebookTracker as any).add(widget);
+    });
+
+    app.docRegistry.addWidgetFactory(factory);
+  }
+};
+
+export default [plugin, legacyPlugin];


### PR DESCRIPTION
Fixes #30 by introducing a "legacy mode" plugin. 

It _appears_ that JupyterLab applies a "last wins" approach to plugins.[^caveat] Therefore, we don't actually need to disable the built-in notebook content factory; we can just shadow the token. We can add a second plugin that checks which content provider is registered, and sets up the context menu if the default plugin is not enabled.

To use legacy mode, disable the `jupyterlab-mystjs:plugin` extension:
```bash
jupyter labextension disable jupyterlab-mystjs:plugin
```

[^caveat]: I don't know this to be true, and can't find any docs. If it turns out this doesn't always hold, then we should be able to rework this.