### PR TITLE
Add html handling to markdown cells

### DIFF
--- a/examples/myst_tests.ipynb
+++ b/examples/myst_tests.ipynb
@@ -138,6 +138,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4c980678-c49c-41a5-a05d-0e38414ca27c",
+   "metadata": {},
+   "source": [
+    "<div><img src=\"https://source.unsplash.com/random/800x300?beach,ocean\" width=\"100px\"></div>\n",
+    "\n",
+    "<!-- just a comment! -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "656a66e1",
    "metadata": {},
    "source": [
@@ -204,7 +214,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.10 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -218,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {

--- a/src/myst.ts
+++ b/src/myst.ts
@@ -12,7 +12,8 @@ import {
   RRIDTransformer,
   linksPlugin,
   ReferenceState,
-  getFrontmatter
+  getFrontmatter,
+  htmlPlugin
 } from 'myst-transforms';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
@@ -39,6 +40,7 @@ export function markdownParse(text: string): Root {
   const mdast = myst.parse(text) as Root;
   unified()
     .use(basicTransformationsPlugin)
+    .use(htmlPlugin, {})
     .runSync(mdast as any);
   return mdast;
 }

--- a/src/myst.ts
+++ b/src/myst.ts
@@ -40,7 +40,15 @@ export function markdownParse(text: string): Root {
   const mdast = myst.parse(text) as Root;
   unified()
     .use(basicTransformationsPlugin)
-    .use(htmlPlugin, {})
+    .use(htmlPlugin, {
+      htmlHandlers: {
+        comment(h: any, node: any) {
+          const result = h(node, 'comment');
+          (result as any).value = node.value;
+          return result;
+        }
+      }
+    })
     .runSync(mdast as any);
   return mdast;
 }


### PR DESCRIPTION
This should address executablebooks/jupyterlab-myst#64 and executablebooks/jupyterlab-mystjs#34 - html is now parsed as best as possible and transformed into myst.

Myst:
![image](https://user-images.githubusercontent.com/9453731/217600715-a7be2162-c1b5-4d6e-be2d-379282cc5c3a.png)

Before:
![image](https://user-images.githubusercontent.com/9453731/217601005-2ee5a491-094c-4538-a4c3-4bfff678976c.png)


After:
![image](https://user-images.githubusercontent.com/9453731/217600784-528e27cf-293a-4f33-8069-1488352a36af.png)
